### PR TITLE
Add workaround for invalid mrv timestamp in the MRV database table

### DIFF
--- a/tymlez-service/src/api/track-and-trace.ts
+++ b/tymlez-service/src/api/track-and-trace.ts
@@ -223,8 +223,9 @@ export const makeTrackAndTraceApi = ({
         deviceId: string | undefined;
       };
 
+      // Note: ignored the MRV record '62130093492a440015975d6f' because it was created by a bug with a timestamp in the future
       const mrv = await processedMrvRepository.findOne({
-        where: { policyTag, deviceId },
+        where: { policyTag, deviceId, id: { $ne: '62130093492a440015975d6f' } },
         order: { timestamp: 'DESC' },
       });
 


### PR DESCRIPTION
What:
----

For some reason, an invalid record with  timestamp  in the future was added to the MRV table.

This breaks the MRV ingestion logic and stops MRV ingestion since it was introduced. 

I could not work out how this was introduced.

Will have to observe after deployment.